### PR TITLE
Refactor errors factory, better docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,31 +21,61 @@ API_DOMAIN=api.app.localhost
 # Application Configuration (ASP.NET API)
 # ============================================================
 
-# JWT Authentication
-JWT__SECRETKEY=YourSuperSecretKeyForDevelopmentOnly123!
-JWT__ISSUER=MyApp
-JWT__AUDIENCE=MyApp
-JWT__ACCESSTOKENEXPIRATIONMINUTES=15
-JWT__REFRESHTOKENEXPIRATIONDAYS=7
+# dotnet run
+ASPNETCORE_ENVIRONMENT=Development
+ASPNETCORE_URLS=http://localhost:5141
 
-# Caching (Memory by default, set to Redis and use --profile cache for Redis container)
+# Host
+# ALLOWEDHOSTS=*
+# SECURITY__ENFORCEHTTPS=true
+
+# CORS
+# CORS__ALLOWEDORIGINS__0=
+# CORS__ALLOWEDORIGINS__1=
+
+# ============================================================
+# Authentication
+# ============================================================
+
+# JWT__SECRETKEY=YOUR-SECRET-KEY-MUST-BE-AT-LEAST-32-CHARACTERS-LONG
+# JWT__ISSUER=MyApp
+# JWT__AUDIENCE=MyApp
+# JWT__ACCESSTOKENEXPIRATIONMINUTES=15
+# JWT__REFRESHTOKENEXPIRATIONDAYS=7
+
+# ============================================================
+# Database & Cache
+# ============================================================
+
+# Database
+# CONNECTIONSTRINGS__DEFAULTCONNECTION=Host=localhost;Port=5432;Database=app;Username=postgres;Password=dev-password-123
+
+# Cache
 CACHING__ENABLED=true
 CACHING__PROVIDER=Memory
-
-# ============================================================
-# Local Development Only (uncomment for `dotnet run`)
-# ============================================================
-
-# ASPNETCORE_ENVIRONMENT=Development
-# ASPNETCORE_URLS=http://localhost:5141
-# CONNECTIONSTRINGS__DEFAULTCONNECTION=Host=localhost;Port=5432;Database=app;Username=postgres;Password=dev-password-123
 # CACHING__REDIS__CONNECTIONSTRING=localhost:6379
+# CACHING__DEFAULTEXPIRATIONMINUTES=5
 
 # ============================================================
-# Production Overrides (reference only)
+# Rate Limiting
 # ============================================================
 
-# POSTGRES_PASSWORD=<use-secrets-manager>
-# JWT__SECRETKEY=<use-secrets-manager>
-# CORS__ALLOWEDORIGINS__0=https://yourdomain.com
-# SECURITY__ENFORCEHTTPS=true
+# Global
+# RATELIMITING__GLOBAL__LIMIT=100
+# RATELIMITING__GLOBAL__WINDOW=60
+
+# Auth Policy
+# RATELIMITING__POLICIES__AUTH__LIMIT=5
+# RATELIMITING__POLICIES__AUTH__WINDOW=60
+
+# Api Policy
+# RATELIMITING__POLICIES__API__LIMIT=30
+# RATELIMITING__POLICIES__API__WINDOW=60
+
+# Relaxed Policy
+# RATELIMITING__POLICIES__RELAXED__LIMIT=60
+# RATELIMITING__POLICIES__RELAXED__WINDOW=60
+
+# Strict Policy
+# RATELIMITING__POLICIES__STRICT__LIMIT=10
+# RATELIMITING__POLICIES__STRICT__WINDOW=60

--- a/Application/Common/Interfaces/ICurrentUserService.cs
+++ b/Application/Common/Interfaces/ICurrentUserService.cs
@@ -8,9 +8,9 @@ public interface ICurrentUserService
 {
     /// <summary>
     /// Gets the current user's internal identifier.
-    /// Returns null if no user is authenticated.
+    /// Throws if no user is authenticated — only use from authenticated endpoints.
     /// </summary>
-    public Guid? UserId { get; }
+    public Guid UserId { get; }
 
     /// <summary>
     /// Gets whether a user is currently authenticated.

--- a/Application/Common/Models/Error.cs
+++ b/Application/Common/Models/Error.cs
@@ -12,6 +12,11 @@ public record Error(string Code, string Description, int StatusCode = 500)
     public IDictionary<string, object?>? Extensions { get; init; }
 
     /// <summary>
+    /// Optional field name for field-level error reporting in ProblemDetails.
+    /// </summary>
+    public string? Field { get; init; }
+
+    /// <summary>
     /// Represents no error (success state).
     /// </summary>
     public static readonly Error None = new(string.Empty, string.Empty, 200);
@@ -22,10 +27,10 @@ public record Error(string Code, string Description, int StatusCode = 500)
     public static readonly Error NullValue = new("NullValue", "A null value was provided.", 400);
 
     /// <summary>
-    /// Creates an error from an <see cref="ErrorCode"/> enum value, using defaults from <see cref="ErrorInfoAttribute"/>.
+    /// Creates an error from an <see cref="ErrorCode"/> enum value, with an optional field and message override.
     /// </summary>
-    public static Error Create(ErrorCode code, string? message = null) =>
-        new(code.ToString(), message ?? code.GetDefaultMessage(), code.GetStatusCode());
+    public static Error From(ErrorCode code, string? field = null, string? message = null) =>
+        new(code.ToString(), message ?? code.GetDefaultMessage(), code.GetStatusCode()) { Field = field };
 
     /// <summary>
     /// Creates a not found error for a specific entity by ID.
@@ -39,35 +44,10 @@ public record Error(string Code, string Description, int StatusCode = 500)
     public static Error NotFound(string description) => new("NotFound", description, 404);
 
     /// <summary>
-    /// Creates a generic validation error. Prefer <see cref="ValidationError.ForField"/> for field-specific errors.
-    /// </summary>
-    public static Error Validation(string description) => new("ValidationError", description, 400);
-
-    /// <summary>
-    /// Creates a generic conflict error.
-    /// </summary>
-    public static Error Conflict(string description) => new("Conflict", description, 409);
-
-    /// <summary>
-    /// Creates a conflict error with a custom code.
-    /// </summary>
-    public static Error Conflict(string code, string description) => new(code, description, 409);
-
-    /// <summary>
     /// Creates an unauthorized error.
     /// </summary>
     public static Error Unauthorized(string description = "You are not authorized to perform this action.") =>
         new("Unauthorized", description, 401);
-
-    /// <summary>
-    /// Creates an unauthorized error with a custom code.
-    /// </summary>
-    public static Error Unauthorized(string code, string description) => new(code, description, 401);
-
-    /// <summary>
-    /// Creates a bad request error with a custom code.
-    /// </summary>
-    public static Error BadRequest(string code, string description) => new(code, description, 400);
 
     /// <summary>
     /// Creates a forbidden error.

--- a/Application/Common/Models/ErrorCode.cs
+++ b/Application/Common/Models/ErrorCode.cs
@@ -9,18 +9,15 @@ namespace Application.Common.Models;
 /// </summary>
 public enum ErrorCode
 {
-    // Authentication errors (400)
+    // Validation errors (400)
     [ErrorInfo(400, "Invalid email or password.")]
     InvalidCredentials,
 
-    [ErrorInfo(400, "Invalid or expired token.")]
-    InvalidResetToken,
+    [ErrorInfo(400, "Invalid or expired password reset token.")]
+    InvalidPasswordResetToken,
 
-    [ErrorInfo(400, "Email is already verified.")]
-    EmailAlreadyVerified,
-
-    [ErrorInfo(400, "Invalid or expired verification token.")]
-    InvalidVerificationToken,
+    [ErrorInfo(400, "Invalid or expired email verification token.")]
+    InvalidEmailVerificationToken,
 
     // Authentication errors (401)
     [ErrorInfo(401, "Authentication is required.")]
@@ -35,9 +32,29 @@ public enum ErrorCode
     [ErrorInfo(401, "User not found.")]
     UserNotFound,
 
+    /// <summary>
+    /// Used by the FluentValidation pipeline. Always includes an <c>errors</c> dictionary in the response.
+    /// Do not use directly in command handlers — use a specific error code instead.
+    /// </summary>
+    [ErrorInfo(400, "One or more validation errors occurred.")]
+    ValidationFailed,
+
+    // Generic errors
+    [ErrorInfo(404, "The requested resource was not found.")]
+    NotFound,
+
+    [ErrorInfo(401, "You are not authorized to perform this action.")]
+    Unauthorized,
+
+    [ErrorInfo(403, "You do not have permission to access this resource.")]
+    Forbidden,
+
     // Conflict errors (409)
     [ErrorInfo(409, "Email is already registered.")]
     EmailTaken,
+
+    [ErrorInfo(409, "Email is already verified.")]
+    EmailAlreadyVerified,
 }
 
 /// <summary>

--- a/Application/Common/Models/ValidationError.cs
+++ b/Application/Common/Models/ValidationError.cs
@@ -1,61 +1,31 @@
 namespace Application.Common.Models;
 
 /// <summary>
-/// Represents a single field-level error with a code and human-readable message.
+/// Represents a single field-level error with an optional code and human-readable message.
 /// </summary>
-public sealed record FieldError(string Code, string Message);
+public sealed record FieldError(string? Code, string Message);
 
 /// <summary>
 /// Represents a validation error with field-level details.
+/// Used exclusively by the FluentValidation pipeline.
 /// </summary>
 public sealed record ValidationError : Error
 {
     public IReadOnlyDictionary<string, FieldError[]> Errors { get; }
 
     private ValidationError(IReadOnlyDictionary<string, FieldError[]> errors)
-        : base("ValidationError", "One or more validation errors occurred.", 400)
+        : base(ErrorCode.ValidationFailed.ToString(), "One or more validation errors occurred.", 400)
     {
         Errors = errors;
     }
 
     /// <summary>
     /// Creates a validation error from a dictionary of field messages (from FluentValidation pipeline).
-    /// All field error codes default to "ValidationError".
     /// </summary>
     public static ValidationError FromDictionary(IDictionary<string, string[]> errors) =>
         new(
             errors
-                .ToDictionary(
-                    kvp => kvp.Key,
-                    kvp => kvp.Value.Select(msg => new FieldError("ValidationError", msg)).ToArray()
-                )
-                .AsReadOnly()
-        );
-
-    /// <summary>
-    /// Creates a validation error for a single field with an <see cref="ErrorCode"/>.
-    /// </summary>
-    public static ValidationError ForField(string field, ErrorCode code, string? message = null) =>
-        new(
-            new Dictionary<string, FieldError[]>
-            {
-                [field] = [new FieldError(code.ToString(), message ?? code.GetDefaultMessage())],
-            }.AsReadOnly()
-        );
-
-    /// <summary>
-    /// Creates a validation error for multiple fields.
-    /// </summary>
-    public static ValidationError ForFields(params (string Field, ErrorCode Code, string? Message)[] fieldErrors) =>
-        new(
-            fieldErrors
-                .GroupBy(e => e.Field)
-                .ToDictionary(
-                    g => g.Key,
-                    g =>
-                        g.Select(e => new FieldError(e.Code.ToString(), e.Message ?? e.Code.GetDefaultMessage()))
-                            .ToArray()
-                )
+                .ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Select(msg => new FieldError(null, msg)).ToArray())
                 .AsReadOnly()
         );
 }

--- a/Application/Features/Auth/Commands/ForgotPassword/ForgotPasswordCommand.cs
+++ b/Application/Features/Auth/Commands/ForgotPassword/ForgotPasswordCommand.cs
@@ -1,8 +1,5 @@
-using Application.Common.Interfaces;
 using Application.Common.Models;
-using Domain.Entities;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 
 namespace Application.Features.Auth.Commands.ForgotPassword;
 
@@ -10,54 +7,3 @@ namespace Application.Features.Auth.Commands.ForgotPassword;
 /// Command to initiate password reset process.
 /// </summary>
 public sealed record ForgotPasswordCommand(string Email) : IRequest<Result>;
-
-public sealed class ForgotPasswordCommandHandler(IApplicationDbContext context, IEmailService emailService)
-    : IRequestHandler<ForgotPasswordCommand, Result>
-{
-    public async Task<Result> Handle(ForgotPasswordCommand request, CancellationToken cancellationToken)
-    {
-        // Always return success to prevent email enumeration
-        string normalizedEmail = request.Email.ToLowerInvariant();
-        User? user = await context.Users.FirstOrDefaultAsync(u => u.Email == normalizedEmail, cancellationToken);
-
-        if (user is null)
-        {
-            // Don't reveal that user doesn't exist
-            return Result.Success();
-        }
-
-        // Invalidate any existing tokens for this user
-        List<PasswordResetToken> existingTokens = await context
-            .PasswordResetTokens.Where(t => t.UserId == user.Id && !t.IsUsed)
-            .ToListAsync(cancellationToken);
-
-        foreach (PasswordResetToken token in existingTokens)
-        {
-            token.MarkAsUsed();
-        }
-
-        // Create new reset token
-        var resetToken = PasswordResetToken.Create(user.Id);
-        context.PasswordResetTokens.Add(resetToken);
-        await context.SaveChangesAsync(cancellationToken);
-
-        // Send email
-        await emailService.SendAsync(
-            new EmailMessage
-            {
-                To = user.Email,
-                Subject = "Password Reset Request",
-                Body = $"""
-                <h2>Password Reset</h2>
-                <p>You requested a password reset. Use the following token to reset your password:</p>
-                <p><strong>{resetToken.Token}</strong></p>
-                <p>This token will expire in 1 hour.</p>
-                <p>If you didn't request this, please ignore this email.</p>
-                """,
-            },
-            cancellationToken
-        );
-
-        return Result.Success();
-    }
-}

--- a/Application/Features/Auth/Commands/ForgotPassword/ForgotPasswordCommandHandler.cs
+++ b/Application/Features/Auth/Commands/ForgotPassword/ForgotPasswordCommandHandler.cs
@@ -1,0 +1,54 @@
+using Application.Common.Interfaces;
+using Application.Common.Models;
+using Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Features.Auth.Commands.ForgotPassword;
+
+public sealed class ForgotPasswordCommandHandler(IApplicationDbContext context, IEmailService emailService)
+    : IRequestHandler<ForgotPasswordCommand, Result>
+{
+    public async Task<Result> Handle(ForgotPasswordCommand request, CancellationToken cancellationToken)
+    {
+        // Always return success to prevent email enumeration
+        string normalizedEmail = request.Email.ToLowerInvariant();
+        User? user = await context.Users.FirstOrDefaultAsync(u => u.Email == normalizedEmail, cancellationToken);
+
+        // Don't reveal that user doesn't exist
+        if (user is null)
+            return Result.Success();
+
+        // Invalidate any existing tokens for this user
+        List<PasswordResetToken> existingTokens = await context
+            .PasswordResetTokens.Where(t => t.UserId == user.Id && !t.IsUsed)
+            .ToListAsync(cancellationToken);
+
+        foreach (PasswordResetToken token in existingTokens)
+            token.MarkAsUsed();
+
+        // Create new reset token
+        var resetToken = PasswordResetToken.Create(user.Id);
+        context.PasswordResetTokens.Add(resetToken);
+        await context.SaveChangesAsync(cancellationToken);
+
+        // Send email
+        await emailService.SendAsync(
+            new EmailMessage
+            {
+                To = user.Email,
+                Subject = "Password Reset Request",
+                Body = $"""
+                <h2>Password Reset</h2>
+                <p>You requested a password reset. Use the following token to reset your password:</p>
+                <p><strong>{resetToken.Token}</strong></p>
+                <p>This token will expire in 1 hour.</p>
+                <p>If you didn't request this, please ignore this email.</p>
+                """,
+            },
+            cancellationToken
+        );
+
+        return Result.Success();
+    }
+}

--- a/Application/Features/Auth/Commands/Login/LoginCommandHandler.cs
+++ b/Application/Features/Auth/Commands/Login/LoginCommandHandler.cs
@@ -20,11 +20,11 @@ public sealed class LoginCommandHandler(
         User? user = await context.Users.FirstOrDefaultAsync(u => u.Email == normalizedEmail, cancellationToken);
 
         if (user is null)
-            return Result.Failure<AuthTokensResponse>(Error.Create(ErrorCode.InvalidCredentials));
+            return Result.Failure<AuthTokensResponse>(Error.From(ErrorCode.InvalidCredentials, "password"));
 
         // Verify password
         if (!passwordHasher.Verify(request.Password, user.PasswordHash))
-            return Result.Failure<AuthTokensResponse>(Error.Create(ErrorCode.InvalidCredentials));
+            return Result.Failure<AuthTokensResponse>(Error.From(ErrorCode.InvalidCredentials, "password"));
 
         // Create refresh token
         string refreshTokenValue = jwtService.GenerateRefreshToken();

--- a/Application/Features/Auth/Commands/Logout/LogoutCommandHandler.cs
+++ b/Application/Features/Auth/Commands/Logout/LogoutCommandHandler.cs
@@ -10,10 +10,7 @@ public sealed class LogoutCommandHandler(IApplicationDbContext context, ICurrent
 {
     public async Task<Result> Handle(LogoutCommand request, CancellationToken cancellationToken)
     {
-        Guid? userId = currentUserService.UserId;
-
-        if (userId is null)
-            return Result.Failure(Error.Create(ErrorCode.NotAuthenticated));
+        Guid userId = currentUserService.UserId;
 
         if (request.RefreshToken is not null)
         {
@@ -24,9 +21,7 @@ public sealed class LogoutCommandHandler(IApplicationDbContext context, ICurrent
             );
 
             if (refreshToken is not null && !refreshToken.IsRevoked)
-            {
                 refreshToken.Revoke();
-            }
         }
         else
         {
@@ -36,9 +31,7 @@ public sealed class LogoutCommandHandler(IApplicationDbContext context, ICurrent
                 .ToListAsync(cancellationToken);
 
             foreach (Domain.Entities.RefreshToken token in activeTokens)
-            {
                 token.Revoke();
-            }
         }
 
         await context.SaveChangesAsync(cancellationToken);

--- a/Application/Features/Auth/Commands/RefreshToken/RefreshTokenCommandHandler.cs
+++ b/Application/Features/Auth/Commands/RefreshToken/RefreshTokenCommandHandler.cs
@@ -21,7 +21,7 @@ public sealed class RefreshTokenCommandHandler(
         Guid? userId = jwtService.GetUserIdFromToken(request.AccessToken);
 
         if (userId is null)
-            return Result.Failure<AuthTokensResponse>(Error.Create(ErrorCode.InvalidToken));
+            return Result.Failure<AuthTokensResponse>(Error.From(ErrorCode.InvalidToken));
 
         // Find the refresh token
         Domain.Entities.RefreshToken? refreshToken = await context.RefreshTokens.FirstOrDefaultAsync(
@@ -30,13 +30,13 @@ public sealed class RefreshTokenCommandHandler(
         );
 
         if (refreshToken is null || !refreshToken.IsValid)
-            return Result.Failure<AuthTokensResponse>(Error.Create(ErrorCode.InvalidRefreshToken));
+            return Result.Failure<AuthTokensResponse>(Error.From(ErrorCode.InvalidRefreshToken));
 
         // Get user
         User? user = await context.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
 
         if (user is null)
-            return Result.Failure<AuthTokensResponse>(Error.Create(ErrorCode.UserNotFound));
+            return Result.Failure<AuthTokensResponse>(Error.From(ErrorCode.UserNotFound));
 
         // Revoke old refresh token
         refreshToken.Revoke();

--- a/Application/Features/Auth/Commands/Register/RegisterCommandHandler.cs
+++ b/Application/Features/Auth/Commands/Register/RegisterCommandHandler.cs
@@ -20,7 +20,7 @@ public sealed class RegisterCommandHandler(
         bool emailExists = await context.Users.AnyAsync(u => u.Email == normalizedEmail, cancellationToken);
 
         if (emailExists)
-            return Result.Failure<AuthTokensResponse>(Error.Create(ErrorCode.EmailTaken));
+            return Result.Failure<AuthTokensResponse>(Error.From(ErrorCode.EmailTaken, "email"));
 
         // Create user
         string passwordHash = passwordHasher.Hash(request.Password);

--- a/Application/Features/Auth/Commands/ResetPassword/ResetPasswordCommand.cs
+++ b/Application/Features/Auth/Commands/ResetPassword/ResetPasswordCommand.cs
@@ -1,58 +1,9 @@
-using Application.Common.Interfaces;
 using Application.Common.Models;
-using Domain.Entities;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 
 namespace Application.Features.Auth.Commands.ResetPassword;
 
 /// <summary>
 /// Command to reset password using a valid token.
 /// </summary>
-public sealed record ResetPasswordCommand(string Email, string Token, string NewPassword) : IRequest<Result>;
-
-public sealed class ResetPasswordCommandHandler(IApplicationDbContext context, IPasswordHasher passwordHasher)
-    : IRequestHandler<ResetPasswordCommand, Result>
-{
-    public async Task<Result> Handle(ResetPasswordCommand request, CancellationToken cancellationToken)
-    {
-        string normalizedEmail = request.Email.ToLowerInvariant();
-        User? user = await context.Users.FirstOrDefaultAsync(u => u.Email == normalizedEmail, cancellationToken);
-
-        if (user is null)
-        {
-            return Result.Failure(Error.Create(ErrorCode.InvalidResetToken, "Invalid email or token."));
-        }
-
-        PasswordResetToken? resetToken = await context.PasswordResetTokens.FirstOrDefaultAsync(
-            t => t.UserId == user.Id && t.Token == request.Token && !t.IsUsed,
-            cancellationToken
-        );
-
-        if (resetToken is null || !resetToken.IsValid())
-        {
-            return Result.Failure(Error.Create(ErrorCode.InvalidResetToken));
-        }
-
-        // Update password
-        string newPasswordHash = passwordHasher.Hash(request.NewPassword);
-        user.UpdatePassword(newPasswordHash);
-
-        // Mark token as used
-        resetToken.MarkAsUsed();
-
-        // Invalidate all refresh tokens for security
-        List<Domain.Entities.RefreshToken> refreshTokens = await context
-            .RefreshTokens.Where(t => t.UserId == user.Id && !t.IsRevoked)
-            .ToListAsync(cancellationToken);
-
-        foreach (Domain.Entities.RefreshToken token in refreshTokens)
-        {
-            token.Revoke();
-        }
-
-        await context.SaveChangesAsync(cancellationToken);
-
-        return Result.Success();
-    }
-}
+public sealed record ResetPasswordCommand(string Token, string NewPassword) : IRequest<Result>;

--- a/Application/Features/Auth/Commands/ResetPassword/ResetPasswordCommandHandler.cs
+++ b/Application/Features/Auth/Commands/ResetPassword/ResetPasswordCommandHandler.cs
@@ -1,0 +1,46 @@
+using Application.Common.Interfaces;
+using Application.Common.Models;
+using Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Features.Auth.Commands.ResetPassword;
+
+public sealed class ResetPasswordCommandHandler(IApplicationDbContext context, IPasswordHasher passwordHasher)
+    : IRequestHandler<ResetPasswordCommand, Result>
+{
+    public async Task<Result> Handle(ResetPasswordCommand request, CancellationToken cancellationToken)
+    {
+        PasswordResetToken? resetToken = await context.PasswordResetTokens.FirstOrDefaultAsync(
+            t => t.Token == request.Token && !t.IsUsed,
+            cancellationToken
+        );
+
+        if (resetToken is null || !resetToken.IsValid())
+            return Result.Failure(Error.From(ErrorCode.InvalidPasswordResetToken));
+
+        User? user = await context.Users.FirstOrDefaultAsync(u => u.Id == resetToken.UserId, cancellationToken);
+
+        if (user is null)
+            return Result.Failure(Error.From(ErrorCode.InvalidPasswordResetToken));
+
+        // Update password
+        string newPasswordHash = passwordHasher.Hash(request.NewPassword);
+        user.UpdatePassword(newPasswordHash);
+
+        // Mark token as used
+        resetToken.MarkAsUsed();
+
+        // Invalidate all refresh tokens for security
+        List<Domain.Entities.RefreshToken> refreshTokens = await context
+            .RefreshTokens.Where(t => t.UserId == user.Id && !t.IsRevoked)
+            .ToListAsync(cancellationToken);
+
+        foreach (Domain.Entities.RefreshToken token in refreshTokens)
+            token.Revoke();
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Application/Features/Auth/Commands/ResetPassword/ResetPasswordCommandValidator.cs
+++ b/Application/Features/Auth/Commands/ResetPassword/ResetPasswordCommandValidator.cs
@@ -6,12 +6,6 @@ public sealed class ResetPasswordCommandValidator : AbstractValidator<ResetPassw
 {
     public ResetPasswordCommandValidator()
     {
-        RuleFor(x => x.Email)
-            .NotEmpty()
-            .WithMessage("Email is required.")
-            .EmailAddress()
-            .WithMessage("Invalid email format.");
-
         RuleFor(x => x.Token).NotEmpty().WithMessage("Token is required.");
 
         RuleFor(x => x.NewPassword)

--- a/Application/Features/Auth/Commands/SendVerificationEmail/SendVerificationEmailCommand.cs
+++ b/Application/Features/Auth/Commands/SendVerificationEmail/SendVerificationEmailCommand.cs
@@ -1,65 +1,9 @@
-using Application.Common.Interfaces;
 using Application.Common.Models;
-using Domain.Entities;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 
 namespace Application.Features.Auth.Commands.SendVerificationEmail;
 
 /// <summary>
 /// Command to send email verification link.
 /// </summary>
-public sealed record SendVerificationEmailCommand(Guid UserId) : IRequest<Result>;
-
-public sealed class SendVerificationEmailCommandHandler(IApplicationDbContext context, IEmailService emailService)
-    : IRequestHandler<SendVerificationEmailCommand, Result>
-{
-    public async Task<Result> Handle(SendVerificationEmailCommand request, CancellationToken cancellationToken)
-    {
-        User? user = await context.Users.FindAsync([request.UserId], cancellationToken);
-
-        if (user is null)
-        {
-            return Result.Failure(Error.NotFound("User", request.UserId));
-        }
-
-        if (user.EmailVerified)
-        {
-            return Result.Failure(Error.Create(ErrorCode.EmailAlreadyVerified));
-        }
-
-        // Invalidate existing tokens
-        List<EmailVerificationToken> existingTokens = await context
-            .EmailVerificationTokens.Where(t => t.UserId == user.Id && !t.IsUsed)
-            .ToListAsync(cancellationToken);
-
-        foreach (EmailVerificationToken token in existingTokens)
-        {
-            token.MarkAsUsed();
-        }
-
-        // Create new verification token
-        var verificationToken = EmailVerificationToken.Create(user.Id);
-        context.EmailVerificationTokens.Add(verificationToken);
-        await context.SaveChangesAsync(cancellationToken);
-
-        // Send email
-        await emailService.SendAsync(
-            new EmailMessage
-            {
-                To = user.Email,
-                Subject = "Verify Your Email Address",
-                Body = $"""
-                <h2>Email Verification</h2>
-                <p>Please verify your email address using the following token:</p>
-                <p><strong>{verificationToken.Token}</strong></p>
-                <p>This token will expire in 24 hours.</p>
-                <p>If you didn't create an account, please ignore this email.</p>
-                """,
-            },
-            cancellationToken
-        );
-
-        return Result.Success();
-    }
-}
+public sealed record SendVerificationEmailCommand : IRequest<Result>;

--- a/Application/Features/Auth/Commands/SendVerificationEmail/SendVerificationEmailCommandHandler.cs
+++ b/Application/Features/Auth/Commands/SendVerificationEmail/SendVerificationEmailCommandHandler.cs
@@ -1,0 +1,59 @@
+using Application.Common.Interfaces;
+using Application.Common.Models;
+using Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Features.Auth.Commands.SendVerificationEmail;
+
+public sealed class SendVerificationEmailCommandHandler(
+    IApplicationDbContext context,
+    IEmailService emailService,
+    ICurrentUserService currentUserService
+) : IRequestHandler<SendVerificationEmailCommand, Result>
+{
+    public async Task<Result> Handle(SendVerificationEmailCommand request, CancellationToken cancellationToken)
+    {
+        Guid userId = currentUserService.UserId;
+
+        User? user = await context.Users.FindAsync([userId], cancellationToken);
+
+        if (user is null)
+            return Result.Failure(Error.NotFound("User", userId));
+
+        if (user.EmailVerified)
+            return Result.Failure(Error.From(ErrorCode.EmailAlreadyVerified, "email"));
+
+        // Invalidate existing tokens
+        List<EmailVerificationToken> existingTokens = await context
+            .EmailVerificationTokens.Where(t => t.UserId == user.Id && !t.IsUsed)
+            .ToListAsync(cancellationToken);
+
+        foreach (EmailVerificationToken token in existingTokens)
+            token.MarkAsUsed();
+
+        // Create new verification token
+        var verificationToken = EmailVerificationToken.Create(user.Id);
+        context.EmailVerificationTokens.Add(verificationToken);
+        await context.SaveChangesAsync(cancellationToken);
+
+        // Send email
+        await emailService.SendAsync(
+            new EmailMessage
+            {
+                To = user.Email,
+                Subject = "Verify Your Email Address",
+                Body = $"""
+                <h2>Email Verification</h2>
+                <p>Please verify your email address using the following token:</p>
+                <p><strong>{verificationToken.Token}</strong></p>
+                <p>This token will expire in 24 hours.</p>
+                <p>If you didn't create an account, please ignore this email.</p>
+                """,
+            },
+            cancellationToken
+        );
+
+        return Result.Success();
+    }
+}

--- a/Application/Features/Auth/Commands/VerifyEmail/VerifyEmailCommand.cs
+++ b/Application/Features/Auth/Commands/VerifyEmail/VerifyEmailCommand.cs
@@ -1,49 +1,9 @@
-using Application.Common.Interfaces;
 using Application.Common.Models;
-using Domain.Entities;
 using MediatR;
-using Microsoft.EntityFrameworkCore;
 
 namespace Application.Features.Auth.Commands.VerifyEmail;
 
 /// <summary>
 /// Command to verify email using a token.
 /// </summary>
-public sealed record VerifyEmailCommand(Guid UserId, string Token) : IRequest<Result>;
-
-public sealed class VerifyEmailCommandHandler(IApplicationDbContext context)
-    : IRequestHandler<VerifyEmailCommand, Result>
-{
-    public async Task<Result> Handle(VerifyEmailCommand request, CancellationToken cancellationToken)
-    {
-        User? user = await context.Users.FindAsync([request.UserId], cancellationToken);
-
-        if (user is null)
-        {
-            return Result.Failure(Error.NotFound("User", request.UserId));
-        }
-
-        if (user.EmailVerified)
-        {
-            return Result.Failure(Error.Create(ErrorCode.EmailAlreadyVerified));
-        }
-
-        EmailVerificationToken? verificationToken = await context.EmailVerificationTokens.FirstOrDefaultAsync(
-            t => t.UserId == user.Id && t.Token == request.Token && !t.IsUsed,
-            cancellationToken
-        );
-
-        if (verificationToken is null || !verificationToken.IsValid())
-        {
-            return Result.Failure(Error.Create(ErrorCode.InvalidVerificationToken));
-        }
-
-        // Verify email
-        user.VerifyEmail();
-        verificationToken.MarkAsUsed();
-
-        await context.SaveChangesAsync(cancellationToken);
-
-        return Result.Success();
-    }
-}
+public sealed record VerifyEmailCommand(string Token) : IRequest<Result>;

--- a/Application/Features/Auth/Commands/VerifyEmail/VerifyEmailCommandHandler.cs
+++ b/Application/Features/Auth/Commands/VerifyEmail/VerifyEmailCommandHandler.cs
@@ -1,0 +1,40 @@
+using Application.Common.Interfaces;
+using Application.Common.Models;
+using Domain.Entities;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Application.Features.Auth.Commands.VerifyEmail;
+
+public sealed class VerifyEmailCommandHandler(IApplicationDbContext context, ICurrentUserService currentUserService)
+    : IRequestHandler<VerifyEmailCommand, Result>
+{
+    public async Task<Result> Handle(VerifyEmailCommand request, CancellationToken cancellationToken)
+    {
+        Guid userId = currentUserService.UserId;
+
+        User? user = await context.Users.FindAsync([userId], cancellationToken);
+
+        if (user is null)
+            return Result.Failure(Error.NotFound("User", userId));
+
+        if (user.EmailVerified)
+            return Result.Failure(Error.From(ErrorCode.EmailAlreadyVerified));
+
+        EmailVerificationToken? verificationToken = await context.EmailVerificationTokens.FirstOrDefaultAsync(
+            t => t.UserId == user.Id && t.Token == request.Token && !t.IsUsed,
+            cancellationToken
+        );
+
+        if (verificationToken is null || !verificationToken.IsValid())
+            return Result.Failure(Error.From(ErrorCode.InvalidEmailVerificationToken));
+
+        // Verify email
+        user.VerifyEmail();
+        verificationToken.MarkAsUsed();
+
+        await context.SaveChangesAsync(cancellationToken);
+
+        return Result.Success();
+    }
+}

--- a/Application/Features/Auth/Commands/VerifyEmail/VerifyEmailCommandValidator.cs
+++ b/Application/Features/Auth/Commands/VerifyEmail/VerifyEmailCommandValidator.cs
@@ -6,8 +6,6 @@ public sealed class VerifyEmailCommandValidator : AbstractValidator<VerifyEmailC
 {
     public VerifyEmailCommandValidator()
     {
-        RuleFor(x => x.UserId).NotEmpty().WithMessage("User ID is required.");
-
         RuleFor(x => x.Token).NotEmpty().WithMessage("Verification token is required.");
     }
 }

--- a/Application/Features/Auth/Queries/GetCurrentUser/GetCurrentUserQueryHandler.cs
+++ b/Application/Features/Auth/Queries/GetCurrentUser/GetCurrentUserQueryHandler.cs
@@ -13,12 +13,7 @@ public sealed class GetCurrentUserQueryHandler(IApplicationDbContext context, IC
         CancellationToken cancellationToken
     )
     {
-        Guid? userId = currentUserService.UserId;
-
-        if (userId is null)
-        {
-            return Result.Failure<CurrentUserResponse>(Error.Create(ErrorCode.NotAuthenticated));
-        }
+        Guid userId = currentUserService.UserId;
 
         CurrentUserResponse? user = await context
             .Users.Where(u => u.Id == userId)

--- a/Application/Features/Auth/Queries/GetSessions/GetSessionsQueryHandler.cs
+++ b/Application/Features/Auth/Queries/GetSessions/GetSessionsQueryHandler.cs
@@ -13,12 +13,7 @@ public sealed class GetSessionsQueryHandler(IApplicationDbContext context, ICurr
         CancellationToken cancellationToken
     )
     {
-        Guid? userId = currentUserService.UserId;
-
-        if (userId is null)
-        {
-            return Result.Failure<IReadOnlyList<Session>>(Error.Create(ErrorCode.NotAuthenticated));
-        }
+        Guid userId = currentUserService.UserId;
 
         List<Session> sessions = await context
             .RefreshTokens.Where(rt => rt.UserId == userId && !rt.IsRevoked && rt.ExpiresAt > DateTime.UtcNow)

--- a/README.md
+++ b/README.md
@@ -8,778 +8,96 @@
 
 A production-ready ASP.NET Core 10.0 template implementing Clean Architecture with CQRS pattern.
 
-## Using as Template
+## Why This Template
 
-### Installation
+`dotnet new webapi` gives you a single-file API with no structure. That's fine for a demo. For anything real, you'll spend weeks making the same decisions every team makes: how to organize code, where validation goes, how errors reach the client, how auth works, how to test without a running database. This template makes those decisions upfront so you can start building features on day one.
 
-```bash
-# Install from local clone
-git clone https://github.com/AnriaruDoragon/ASP-Clean-Architecture
-dotnet new install ./ASPCleanArchitecture
+### Why Clean Architecture?
+
+Most projects start as a single Web API project. Dependencies leak everywhere: controllers call EF Core directly, business logic lives in services that are impossible to test without a database, and swapping out infrastructure (say, moving from SQL Server to PostgreSQL) means touching half your codebase.
+
+Clean Architecture enforces boundaries. Domain logic has zero dependencies. Application logic depends only on abstractions. Infrastructure is a pluggable detail. The result: you can test business rules without a database, swap caching providers without touching handlers, and read any handler in isolation because its dependencies are explicit.
+
+### Why CQRS?
+
+Service classes grow into god objects. `UserService` starts with `Register()` and `Login()`, then accumulates `UpdateProfile()`, `ChangePassword()`, `GetSessions()`, `RevokeSession()` until it has 20 methods and 15 constructor dependencies.
+
+CQRS replaces services with focused handlers. Each handler does one thing, takes one request, returns one result. Dependencies are exactly what that operation needs. Testing is straightforward: construct the handler, call `Handle()`, assert the result. No mocking 14 unused dependencies to test one method.
+
+### Why the Result pattern?
+
+Exceptions are invisible control flow. A method signature says it returns `User`, but it might throw `NotFoundException`, `ValidationException`, `UnauthorizedException` — you won't know until you read the implementation or hit it at runtime. Callers forget to catch, and you get 500s in production.
+
+`Result<T>` makes failure explicit. The return type tells you this operation can fail. The compiler forces you to handle both paths. Errors carry typed codes (`ErrorCode` enum) that frontends can match on for i18n, instead of parsing human-readable strings.
+
+### Why secure by default?
+
+Most frameworks require you to opt *in* to authentication with `[Authorize]`. Forget it on one endpoint and you have an unauthenticated route in production. This template flips it: all endpoints require authentication by default. You opt *out* with `[Public]` — a deliberate, visible decision.
+
+## What's Included
+
+| Feature | Why |
+|---|---|
+| **JWT auth with refresh tokens** | Stateless authentication with revocable sessions. Multi-device support out of the box. |
+| **CQRS with MediatR** | One handler per operation. Explicit dependencies. Easy to test. |
+| **FluentValidation pipeline** | Validation runs before the handler, automatically. You can't forget it. |
+| **Result + ProblemDetails errors** | Typed error codes (`ErrorCode` enum) in RFC 7807 responses. Frontends can match on codes, not strings. |
+| **Rate limiting** | Per-IP, per-user, and per-session rate limiting. Configurable policies via `appsettings.json`. |
+| **Domain events** | Entities announce what happened. Handlers react. No coupling between the two. |
+| **API versioning** | Header-based versioning with per-version OpenAPI docs and lifecycle management. |
+| **Caching pipeline** | Implement `ICacheableQuery` on a query and it's cached. Memory or Redis backends. |
+| **Background jobs** | Fire-and-forget or queued jobs via `IBackgroundJobService`. Swap in Hangfire for production. |
+| **Health checks** | Liveness and readiness probes for orchestrators. Database connectivity included. |
+| **Structured logging** | Serilog with correlation IDs for distributed tracing. |
+| **Docker + Traefik** | Development stack with HTTPS via Traefik. Production stack with Nginx. |
+
+## Architecture
+
+```
+Domain/           Entities, value objects, domain events. No dependencies.
+Application/      CQRS handlers, validators, interfaces. Depends on Domain.
+Infrastructure/   EF Core, JWT, email, caching. Depends on Application.
+Web.API/          Controllers, middleware. Depends on all layers.
 ```
 
-### Create a New Project
+**Dependency flow:** `Domain` <- `Application` <- `Infrastructure` <- `Web.API`
 
-```bash
-# Default: all features included (with auto-setup)
-dotnet new aspclean -n MyApp --allow-scripts yes
+Each layer only knows about the layer directly below it (through interfaces). Infrastructure details like databases, email providers, and JWT tokens are invisible to Application — it works with `IApplicationDbContext`, `IEmailService`, and `IJwtService`.
 
-# Without auto-setup (manual post-creation steps)
-dotnet new aspclean -n MyApp
-
-# Without Docker files
-dotnet new aspclean -n MyApp --IncludeDocker false --allow-scripts yes
-
-# Without example Product feature
-dotnet new aspclean -n MyApp --IncludeExamples false --allow-scripts yes
-
-# Minimal: no examples, no docker, no tests
-dotnet new aspclean -n MyApp --IncludeExamples false --IncludeDocker false --IncludeTests false --allow-scripts yes
-```
-
-> **Note:** `--allow-scripts yes` automatically runs post-creation scripts (restore, copy .env, create migration).
-> Without it, you'll be prompted to confirm each action or can run them manually.
-
-### Template Parameters
-
-| Parameter           | Default | Description                   |
-|---------------------|---------|-------------------------------|
-| `--IncludeExamples` | `true`  | Include Products CRUD example |
-| `--IncludeDocker`   | `true`  | Include Docker/compose files  |
-| `--IncludeTests`    | `true`  | Include test projects         |
-
-### After Creating a Project
-
-We recommend to install [Taskfile](https://taskfile.dev/docs/installation) to use predefined tasks.
-
-With `--allow-scripts yes`, steps 1-3 run automatically.
-
-```bash
-cd MyApp
-
-# 1. Setup environment (auto)
-cp .env.example .env
-
-# 2. Restore packages (auto)
-task restore
-
-# 3. Create initial migration (auto)
-task migration:add -- Init
-
-# 4. (Optional) Setup local HTTPS
-task certs:setup:windows  # Windows
-task certs:setup          # Linux/Mac
-
-# 5. Start development
-task docker:up
-```
-
----
+**Why this matters:** You can test any handler by providing a mock `IApplicationDbContext`. You can swap PostgreSQL for SQL Server by changing one project. You can replace JWT with API keys without touching a single handler.
 
 ## Quick Start
 
 ```bash
-# 1. Setup environment
-cp .env.example .env
+# Install template
+git clone https://github.com/AnriaruDoragon/ASP-Clean-Architecture
+dotnet new install ./ASPCleanArchitecture
 
-# 2. Start development environment
-task docker:up            # Windows/Mac: DB+Traefik, Linux: full stack
-task watch                # Run API locally (Windows/Mac)
+# Create project (auto-setup: restore, .env, migration)
+dotnet new aspclean -n MyApp --allow-scripts yes
+cd MyApp
+
+# Start development
+task docker:up    # Start DB + Redis + Traefik
+task watch        # Run API with hot-reload
 
 # Access: http://localhost:5141
+# API docs: http://localhost:5141/scalar/v1
 ```
 
-**Optional: Local HTTPS domain** (production-like setup)
-```bash
-# Generate HTTPS certificates and configure hosts (requires mkcert)
-# Run as admin/sudo to auto-add hosts entry
-task certs:setup:windows  # Windows (run as Administrator)
-task certs:setup          # Linux/Mac (uses sudo)
-
-# Access: https://api.app.localhost
-```
-
-**Optional: Redis caching**
-```bash
-# Enable Redis in .env
-CACHING__PROVIDER=Redis
-
-# Start with Redis profile
-docker compose --profile cache up -d
-```
-
-## Development Setup
-
-### Prerequisites
-
-- [.NET 10 SDK](https://dotnet.microsoft.com/download)
-- [Docker Desktop](https://www.docker.com/products/docker-desktop)
-- [Task](https://taskfile.dev/) (task runner)
-- [mkcert](https://github.com/FiloSottile/mkcert) *(optional, for local HTTPS)*
-
-### First-Time Setup
-
-1. **Copy environment file and restore tools:**
-   ```bash
-   cp .env.example .env
-   dotnet tool restore
-   ```
-
-2. **(Optional) Local HTTPS domain setup:**
-   ```bash
-   # Generate certificates and configure hosts (requires mkcert)
-   # Run as admin/sudo to auto-add hosts entry
-   task certs:setup:windows  # Windows (run as Administrator)
-   task certs:setup          # Linux/Mac (uses sudo)
-   ```
-
-### Development Workflow
-
-**Windows/Mac** (recommended): Run DB + Redis in Docker, .NET locally via IDE:
-```bash
-task docker:up   # Start infrastructure (DB, Redis, Traefik)
-task watch       # Run API with hot-reload
-```
-
-**Linux**: Run everything in Docker:
-```bash
-task docker:up   # Starts full stack including API container
-```
-
-**Development Endpoints:**
-
-| Endpoint          | URL                                                 |
-|-------------------|-----------------------------------------------------|
-| API (direct)      | http://localhost:5141                               |
-| API (via Traefik) | https://api.app.localhost *(requires hosts entry)*  |
-| Scalar API docs   | http://localhost:5141/scalar/v1                     |
-| Traefik Dashboard | http://localhost:8080                               |
-
-### Redis Caching (Optional)
-
-Redis is available but not started by default. To enable:
-
-```bash
-# Set in .env
-CACHING__PROVIDER=Redis
-
-# Start with cache profile
-docker compose --profile cache up -d
-```
-
-### Docker Commands
-
-| Command                | Description                                   |
-|------------------------|-----------------------------------------------|
-| `task docker:up`       | Smart start (Windows/Mac: infra, Linux: full) |
-| `task docker:up:infra` | Start infrastructure only                     |
-| `task docker:up:full`  | Start full stack with API container           |
-| `task docker:down`     | Stop all containers                           |
-| `task docker:logs`     | View container logs                           |
-| `task docker:clean`    | Remove containers and volumes                 |
-
-## Production Deployment
-
-### Docker Compose
-
-```bash
-# Configure production values in .env
-task prod:up     # Build and start production stack
-task prod:logs   # View logs
-task prod:down   # Stop
-```
-
-**Production services:**
-- **PostgreSQL 18** - Database (internal only)
-- **Redis 8** - Distributed caching (internal only, optional)
-- **API** - ASP.NET Core application
-- **Nginx** - Reverse proxy with HTTPS
-
-### VM/EC2 Deployment
-
-Build a self-contained package for deployment to VMs:
-
-```bash
-# Build for Linux x64 (default)
-task deploy:build
-
-# Build for different runtime
-task deploy:build DEPLOY_RUNTIME=linux-arm64  # ARM64 (AWS Graviton)
-task deploy:build DEPLOY_RUNTIME=win-x64      # Windows
-
-# Create deployment package
-task deploy:package          # Creates .tar.gz (Linux/Mac)
-task deploy:package:windows  # Creates .zip (Windows)
-```
-
-**Systemd service example** (`/etc/systemd/system/myapp.service`):
-```ini
-[Unit]
-Description=ASP.NET Clean Architecture API
-After=network.target
-
-[Service]
-Type=notify
-User=www-data
-WorkingDirectory=/opt/myapp
-ExecStart=/opt/myapp/Web.API
-Restart=always
-RestartSec=10
-Environment=ASPNETCORE_ENVIRONMENT=Production
-Environment=ASPNETCORE_URLS=http://localhost:5000
-
-[Install]
-WantedBy=multi-user.target
-```
-
-## Build & Test Commands
-
-```bash
-# Build
-task build              # Debug build
-task build:release      # Release build
-
-# Run
-task run                # Run API
-task watch              # Run with hot-reload
-
-# Test
-task test               # All tests
-task test:unit          # Unit tests only
-task test:integration   # Integration tests
-
-# EF Core Migrations
-task migration:add -- Name    # Create migration
-task db:update                # Apply migrations
-task db:shell                 # PostgreSQL shell
-```
-
-### Taskfile Commands
-
-```bash
-# Development
-task docker:up          # Start dev environment (smart)
-task docker:down        # Stop dev environment
-task watch              # Run with hot reload
-
-# Production
-task prod:up            # Start production containers
-task prod:down          # Stop production containers
-
-# Deploy (VM/EC2)
-task deploy:build       # Build self-contained package
-task deploy:package     # Create deployment tarball/zip
-
-# Testing
-task test               # Run all tests
-task test:unit          # Unit tests only
-task test:coverage      # Tests with coverage
-
-# Database
-task migration:add -- Name    # Create migration
-task db:update                # Apply migrations
-task db:shell                 # Database shell
-
-# Utilities
-task format             # Format code (dotnet format + CSharpier)
-task format:check       # Check formatting without changes
-task info               # Show environment info
-```
-
-View all commands: `task --list-all`
-
-## Architecture
-
-ASP.NET Core 10.0 Clean Architecture with CQRS pattern:
-
-```
-Domain/           → Entities, value objects, domain events (no dependencies)
-Application/      → CQRS handlers, validators, interfaces (depends on Domain)
-Infrastructure/   → EF Core, repositories, external services (depends on Application)
-Web.API/          → Controllers, middleware (depends on all layers)
-Common.ApiVersioning/ → Shared API versioning library (standalone)
-```
-
-**Dependency Flow:** Domain ← Application ← Infrastructure ← Web.API
-
-### Domain Layer
-
-Base classes for entities:
-- `BaseEntity` - Id + domain events support
-- `AuditableEntity` - Adds CreatedAt/By, ModifiedAt/By
-- `IAggregateRoot` - Marker for aggregate roots (only these get repositories)
-- `ValueObject` - Base for value objects (equality by value)
-- `IDomainEvent` - Domain event interface
-
-### Application Layer
-
-**CQRS with MediatR:**
-- Commands: `ICommand`, `ICommand<TResponse>` → `ICommandHandler<T>`
-- Queries: `IQuery<TResponse>` → `IQueryHandler<T, TResponse>`
-- All handlers return `Result` or `Result<T>` (never throw for expected failures)
-
-**Pipeline Behaviors:**
-- `ValidationBehavior` - Auto-validates requests via FluentValidation
-- `LoggingBehavior` - Logs request execution and timing
-- `CachingBehavior` - Caches query results for `ICacheableQuery` implementations
-
-**Interfaces defined here, implemented in Infrastructure:**
-- `IRepository<T>` - Generic repository for aggregate roots
-- `IUnitOfWork` - Transaction coordination
-- `IApplicationDbContext` - DbContext abstraction (includes `Database` property for raw database access)
-- `ICurrentUserService` - Current user access
-- `IDateTimeProvider` - Testable time
-
-### Infrastructure Layer
-
-- `ApplicationDbContext` - EF Core DbContext
-- `Repository<T>` - Generic repository implementation
-- `AuditableEntityInterceptor` - Auto-fills audit fields on save
-- `BaseEntityConfiguration<T>` / `AuditableEntityConfiguration<T>` - EF configs
-
-### Web.API Layer
-
-- `GlobalExceptionHandlerMiddleware` - Converts exceptions to RFC 7807 Problem Details
-- `ResultExtensions` - Converts `Result<T>` to appropriate HTTP responses
-- `CurrentUserService` - Implements `ICurrentUserService` from HTTP context
-
-## Adding a New Feature
-
-1. **Entity** (Domain): Create entity inheriting from `AuditableEntity`, implement `IAggregateRoot`
-2. **DbSet** (Application + Infrastructure): Add to `IApplicationDbContext` and `ApplicationDbContext`
-3. **Configuration** (Infrastructure): Create `EntityConfiguration : AuditableEntityConfiguration<Entity>`
-4. **Repository** (optional): Create specific repository if needed beyond generic `IRepository<T>`
-5. **Commands/Queries** (Application): Create in `Features/<FeatureName>/`
-6. **Validators** (Application): Create FluentValidation validators
-7. **Controller** (Web.API): Create in `Controllers/V1/`, use MediatR to send commands/queries
-
-## Examples
-
-### Product Feature (CRUD)
-
-A complete example demonstrating all patterns is included:
-
-- **Entity**: `Domain/Entities/Product.cs` - rich domain model with business logic
-- **Events**: `Domain/Events/ProductCreatedEvent.cs`, `ProductOutOfStockEvent.cs`, `ProductDeletedEvent.cs`
-- **CQRS**: `Application/Features/Products/` - commands, queries, handlers, validators
-- **EF Config**: `Infrastructure/Data/Configs/ProductConfiguration.cs`
-- **Controller**: `Web.API/Controllers/V1/ProductsController.cs` - full CRUD API
-
-**Patterns demonstrated:**
-- **Soft Delete**: Products use soft delete with `IsDeleted` and `DeletedAt` fields, filtered by global query filter
-- **Optimistic Concurrency**: `RowVersion` column prevents concurrent update conflicts
-- **Domain Events**: Events dispatched after successful database save
-- **Pagination**: `PagedList<T>` wrapper with page/size/total metadata
-- **Query Parameters**: `[FromQuery]` binding with FluentValidation rules visible in OpenAPI
-
-### File Upload
-
-Demonstrates file upload with validation:
-
-- **Command**: `Application/Features/Files/Commands/UploadFile/` - command, handler, validator
-- **Controller**: `Web.API/Controllers/V1/FilesController.cs` - upload endpoint
-- **Validation**: Custom FluentValidation extensions for file size, content type, and extension checks
-
-Use these as a reference when adding new features.
-
-### Removing the Products Example
-
-To start fresh without the example feature, run the removal script:
-
-```shell
-# Linux/Mac
-./scripts/remove-products-example.sh
-```
-
-```powershell
-# Windows (PowerShell)
-.\scripts\remove-products-example.ps1
-```
-
-This removes all Products-related files, updates the DbContext, and self-deletes the scripts. After running:
-1. Run `dotnet build` to verify no errors
-2. Create a new migration or keep the existing Auth migration
-
-## Authentication & Authorization
-
-### JWT Authentication
-
-JWT tokens are used for **authentication only** (proving WHO you are). Authorization is checked against the database on each request, ensuring role changes take effect immediately.
-
-**Configuration via environment variables** (recommended for CI/CD):
-```bash
-CONNECTIONSTRINGS__DEFAULTCONNECTION=Host=localhost;Database=myapp;Username=postgres;Password=secret
-JWT__SECRETKEY=your-secret-key-min-32-chars
-JWT__ISSUER=MyApp
-JWT__AUDIENCE=MyApp
-```
-
-See `.env.example` for all available variables. Environment variables override `appsettings.json`.
-
-### Secure by Default
-
-All endpoints require authentication by default. Use attributes to customize:
-
-```csharp
-[Public]                      // No authentication required
-[RequireRole(Role.Admin)]     // Requires Admin role (checked against DB)
-[EmailVerified]               // Requires verified email (checked against DB)
-```
-
-### Auth Endpoints
-
-| Endpoint              | Method | Description              |
-|-----------------------|--------|--------------------------|
-| `/Auth/Register`      | POST   | Register new user        |
-| `/Auth/Login`         | POST   | Login, returns tokens    |
-| `/Auth/Refresh`       | POST   | Refresh access token     |
-| `/Auth/Logout`        | POST   | Revoke refresh token(s)  |
-| `/Auth/Me`            | GET    | Get current user profile |
-| `/Auth/Sessions`      | GET    | List active sessions     |
-| `/Auth/Sessions/{id}` | DELETE | Revoke specific session  |
-
-### Multi-Device Support
-
-- Each login creates a separate refresh token (session)
-- Users can be logged in on multiple devices simultaneously
-- Sessions can be viewed and revoked individually
-- Device name and user agent stored for identification
-
-### Creating Custom Guards
-
-Use `[EmailVerified]` as a template. Create:
-1. Attribute in `Web.API/Authorization/`
-2. Requirement in `Web.API/Authorization/Requirements/`
-3. Handler in `Web.API/Authorization/Handlers/`
-4. Register policy in `AuthorizationPolicyProvider.cs`
-
-## API Versioning & OpenAPI
-
-The `Common.ApiVersioning` library provides API versioning, OpenAPI documentation, Scalar UI, and version lifecycle management. It's designed as a **standalone library** that can be used in any ASP.NET Core project.
-
-**Quick Setup:**
-
-```csharp
-// Program.cs
-builder.Services.AddApiVersioningServices(builder.Configuration);
-
-var app = builder.Build();
-app.UseScalarApiReference();  // Scalar UI (dev recommended)
-app.UseMiddleware<ApiVersioningDeprecationMiddleware>();  // Version lifecycle
-app.MapControllers();
-```
-
-**Key Features:**
-- Header-based versioning (`x-api-version`)
-- Namespace convention (`Controllers.V1` → version 1)
-- Version lifecycle management (Active → Deprecated → Sunset)
-- Automatic OpenAPI 3.0 document generation per version
-- Scalar interactive documentation UI
-- FluentValidation rules extracted to OpenAPI schemas (request bodies and query parameters)
-- Numeric type fix for .NET 10's multi-type schema generation
-
-**Endpoints:**
-
-| Endpoint                  | Description                         |
-|---------------------------|-------------------------------------|
-| `/openapi/{version}.json` | OpenAPI 3.0 specification           |
-| `/scalar`                 | Scalar interactive documentation UI |
-
-For complete documentation including configuration options, version statuses, lifecycle headers, and advanced usage, see **[Common.ApiVersioning/README.md](Common.ApiVersioning/README.md)**.
-
-## Health Checks
-
-Health check endpoints for monitoring and orchestration:
-
-| Endpoint        | Description                                     |
-|-----------------|-------------------------------------------------|
-| `/health/live`  | Liveness probe - is the app running?            |
-| `/health/ready` | Readiness probe - is the app ready for traffic? |
-
-The readiness check includes database connectivity. Responses use the standard health check UI format.
-
-```bash
-# Check if API is ready
-curl http://localhost:5141/health/ready
-```
-
-## Observability
-
-### Serilog Structured Logging
-
-Serilog is configured for structured logging with console output. Configure log levels via `appsettings.json`:
-
-```json
-"Serilog": {
-  "MinimumLevel": {
-    "Default": "Information",
-    "Override": {
-      "Microsoft": "Warning",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}
-```
-
-### Correlation ID
-
-Every request is assigned a unique correlation ID for distributed tracing:
-
-- **Header**: `X-Correlation-ID`
-- Reads from request header or generates new GUID
-- Included in all logs via Serilog LogContext
-- Returned in response headers
-- Included in error responses (ProblemDetails)
-
-```bash
-# Pass a correlation ID
-curl -H "X-Correlation-ID: my-trace-123" http://localhost:5141/Products
-```
-
-### Request Logging
-
-Debug-level logging of HTTP requests and responses. Automatically:
-- Logs request method, path, and sanitized headers
-- Logs response status code and timing
-- Excludes health check endpoints
-- Redacts sensitive headers (Authorization, Cookie, API keys)
-
-Enable by setting Serilog minimum level to `Debug` in development.
-
-### OpenTelemetry (Recommended)
-
-For production observability, add OpenTelemetry instrumentation:
-
-```xml
-<!-- Web.API.csproj -->
-<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
-<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
-<PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
-<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
-```
-
-See [OpenTelemetry .NET documentation](https://opentelemetry.io/docs/languages/net/) for setup.
-
-## Rate Limiting
-
-Built-in rate limiting protects against abuse:
-
-**Configuration (`appsettings.json`):**
-```json
-"RateLimiting": {
-  "Global": { "PermitLimit": 100, "WindowMinutes": 1 },
-  "Api": { "PermitLimit": 30, "WindowMinutes": 1 }
-}
-```
-
-- **Global limiter**: Applies to all requests per IP
-- **Api limiter**: Apply to specific endpoints with `[EnableRateLimiting("Api")]`
-
-When rate limited, returns `429 Too Many Requests`.
-
-## CORS Configuration
-
-Configure allowed origins in `appsettings.json`:
-
-```json
-"Cors": {
-  "AllowedOrigins": ["https://yourdomain.com", "https://*.yourdomain.com"]
-}
-```
-
-Or via environment variable:
-```bash
-CORS__ALLOWEDORIGINS=https://yourdomain.com,https://*.yourdomain.com
-```
-
-**Wildcard Support:**
-- Use `*` for subdomain wildcards: `https://*.example.com`
-- Matches any subdomain: `https://app.example.com`, `https://api.example.com`
-
-**Behavior:**
-- With origins configured: Strict CORS with credentials support
-- In Development without origins: Allow any origin (no credentials)
-
-## Caching
-
-Optional response caching with Memory or Redis backends.
-
-**Configuration (`appsettings.json`):**
-```json
-"Caching": {
-  "Enabled": false,
-  "Provider": "Memory",
-  "Redis": {
-    "ConnectionString": "localhost:6379"
-  },
-  "DefaultExpirationMinutes": 5
-}
-```
-
-**Providers:**
-- `Memory` - In-process memory cache (default)
-- `Redis` - Distributed Redis cache
-- `None` / disabled - No-op (zero overhead)
-
-**Usage in queries:**
-```csharp
-public sealed record GetProductByIdQuery(Guid Id)
-    : IQuery<ProductResponse>, ICacheableQuery
-{
-    public string CacheKey => $"products:{Id}";
-}
-```
-
-Implement `ICacheableQuery` to enable automatic caching via `CachingBehavior`.
-
-Redis is included in the Docker development stack and production deployment.
-
-## Background Jobs
-
-Abstraction for background job processing with pluggable providers.
-
-**Configuration (`appsettings.json`):**
-```json
-"BackgroundJobs": {
-  "Provider": "Instant"
-}
-```
-
-**Providers:**
-- `Instant` - Fire-and-forget after response (default, good for dev)
-- `Memory` - In-memory queue with background worker
-- `None` - Disabled, jobs are dropped
-
-**Usage:**
-```csharp
-public class MyHandler(IBackgroundJobService jobs)
-{
-    public async Task Handle(...)
-    {
-        // Job runs after response is sent
-        await jobs.EnqueueAsync(new SendWelcomeEmailCommand(userId));
-        await jobs.ScheduleAsync(new CleanupCommand(), TimeSpan.FromHours(1));
-    }
-}
-```
-
-**Production: Hangfire with Redis**
-
-For production workloads, replace the built-in providers with [Hangfire](https://www.hangfire.io/):
-
-```bash
-dotnet add Web.API package Hangfire.AspNetCore
-dotnet add Web.API package Hangfire.Redis.StackExchange
-```
-
-```csharp
-// Program.cs
-builder.Services.AddHangfire(config => config
-    .UseRedisStorage(builder.Configuration.GetConnectionString("Redis")));
-builder.Services.AddHangfireServer();
-
-// Usage - same interface, production-ready
-BackgroundJob.Enqueue(() => SendEmail(userId));
-```
-
-Benefits: persistence, retries, dashboard, distributed workers, scheduled jobs.
-
-**Other options:**
-- [Quartz.NET](https://www.quartz-scheduler.net/) - Enterprise cron-style scheduling
-- Message queues (RabbitMQ, Azure Service Bus) - For distributed/microservice scenarios
-
-## Domain Events
-
-Domain events allow entities to announce business-significant occurrences without coupling to handlers.
-
-**Flow:**
-1. Entity raises event: `AddDomainEvent(new ProductCreatedEvent(...))`
-2. Events stored in entity until `SaveChangesAsync()`
-3. Events collected before save, dispatched via MediatR **after successful save**
-
-This ensures data consistency - events are only dispatched after the database transaction commits.
-
-**Creating a new event:**
-
-1. Define event in `Domain/Events/`:
-```csharp
-public sealed record OrderShippedEvent(Guid OrderId) : IDomainEvent
-{
-    public DateTime OccurredOn { get; } = DateTime.UtcNow;
-}
-```
-
-1. Raise from entity:
-```csharp
-public void Ship()
-{
-    Status = OrderStatus.Shipped;
-    AddDomainEvent(new OrderShippedEvent(Id));
-}
-```
-
-1. Create handler in `Application/Features/<Feature>/Events/`:
-```csharp
-public sealed class OrderShippedEventHandler
-    : INotificationHandler<DomainEventNotification<OrderShippedEvent>>
-{
-    public Task Handle(DomainEventNotification<OrderShippedEvent> notification,
-        CancellationToken cancellationToken)
-    {
-        // Send email, update external systems, etc.
-        return Task.CompletedTask;
-    }
-}
-```
-
-**Use cases:** Audit logging, email notifications, cache invalidation, search index updates, message queue publishing.
-
-## Testing
-
-Three test projects are included:
-
-```
-Tests/
-├── Domain.UnitTests/           # Domain entity tests
-├── Application.UnitTests/      # Handler and validator tests
-└── Web.API.IntegrationTests/   # API integration tests with Testcontainers
-```
-
-**Run all tests:**
-```bash
-dotnet test
-```
-
-**Run specific project:**
-```bash
-dotnet test Tests/Domain.UnitTests
-dotnet test Tests/Application.UnitTests
-dotnet test Tests/Web.API.IntegrationTests
-```
-
-**Integration tests** use [Testcontainers](https://testcontainers.com/) to spin up a real PostgreSQL database. Docker must be running.
-
-## Key Patterns
-
-- **API Versioning**: Header-based (`x-api-version`) with namespace conventions (`Controllers.V1`)
-- **Result Pattern**: Use `Result<T>` instead of exceptions for expected failures
-- **Repository Pattern**: Only for aggregate roots via `IRepository<T>`
-- **Unit of Work**: `IUnitOfWork.SaveChangesAsync()` commits all changes atomically
-- **Secure by Default**: All endpoints require authentication unless marked `[Public]`
-
-## Code Style
-
-Enforced via `.editorconfig` and [CSharpier](https://csharpier.com/) (C# 14 / .NET 10):
-
-- **File-scoped namespaces** required
-- **Nullable reference types** enabled
-- **Private fields**: `_camelCase`
-- **Private static fields**: `s_camelCase`
-- **Interfaces**: `I` prefix
-- **No `this.` qualification**
-- **`var`**: Only when type is apparent
-- **Expression-bodied members**: For single-line methods/properties
-- **Line width**: 120 characters (enforced by CSharpier)
+See [Getting Started](docs/getting-started.md) for detailed setup, template parameters, and Docker workflows.
+
+## Documentation
+
+| Guide | Description |
+|---|---|
+| [Getting Started](docs/getting-started.md) | Installation, template parameters, development setup, Docker commands |
+| [Architecture](docs/architecture.md) | Layer responsibilities, CQRS pattern, pipeline behaviors, Result pattern, domain events |
+| [Authentication](docs/authentication.md) | JWT setup, secure-by-default, auth endpoints, custom guards |
+| [Error Handling](docs/error-handling.md) | `Error.From()` pattern, `ErrorCode` enum, validation errors, ProblemDetails format |
+| [Deployment](docs/deployment.md) | Docker Compose production, VM/EC2 deployment, systemd service |
+| [Configuration](docs/configuration.md) | Environment variables, CORS, caching, rate limiting, background jobs, observability |
+| [Adding Features](docs/adding-features.md) | Step-by-step guide, Product CRUD example, file upload example |
 
 ## License
 

--- a/Web.API/Controllers/V1/FilesController.cs
+++ b/Web.API/Controllers/V1/FilesController.cs
@@ -28,6 +28,7 @@ public class FilesController(ISender sender) : ControllerBase
     public async Task<IActionResult> Upload(IFormFile file, CancellationToken cancellationToken)
     {
         var command = new UploadFileCommand(file);
+
         Result<UploadFileResponse> result = await sender.Send(command, cancellationToken);
 
         return result.ToActionResult();

--- a/Web.API/Controllers/V1/ProductsController.cs
+++ b/Web.API/Controllers/V1/ProductsController.cs
@@ -50,6 +50,7 @@ public class ProductsController(ISender sender) : ControllerBase
     public async Task<IActionResult> GetProduct(Guid id, CancellationToken cancellationToken = default)
     {
         var query = new GetProductByIdQuery(id);
+
         Result<ProductResponse> result = await sender.Send(query, cancellationToken);
 
         return result.ToActionResult();
@@ -69,6 +70,7 @@ public class ProductsController(ISender sender) : ControllerBase
     )
     {
         var command = new CreateProductCommand(request.Name, request.Description, request.Price, request.StockQuantity);
+
         Result<Guid> result = await sender.Send(command, cancellationToken);
 
         return result.ToActionResult(id =>
@@ -109,6 +111,7 @@ public class ProductsController(ISender sender) : ControllerBase
     public async Task<IActionResult> DeleteProduct(Guid id, CancellationToken cancellationToken = default)
     {
         var command = new DeleteProductCommand(id);
+
         Result result = await sender.Send(command, cancellationToken);
 
         return result.ToActionResult();

--- a/Web.API/Models/ErrorProblemDetails.cs
+++ b/Web.API/Models/ErrorProblemDetails.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Application.Common.Models;
 using Microsoft.AspNetCore.Mvc;
 
 namespace Web.API.Models;
@@ -10,7 +11,7 @@ namespace Web.API.Models;
 public sealed class ErrorProblemDetails : ProblemDetails
 {
     [JsonPropertyName("errorCode")]
-    public string ErrorCode { get; set; } = null!;
+    public ErrorCode ErrorCode { get; set; }
 
     [JsonPropertyName("errors")]
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
@@ -23,7 +24,8 @@ public sealed class ErrorProblemDetails : ProblemDetails
 public sealed class FieldErrorDetail
 {
     [JsonPropertyName("code")]
-    public string Code { get; set; } = null!;
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Code { get; set; }
 
     [JsonPropertyName("detail")]
     public string Detail { get; set; } = null!;

--- a/docs/adding-features.md
+++ b/docs/adding-features.md
@@ -1,0 +1,72 @@
+# Adding Features
+
+## Step by Step
+
+1. **Entity** (Domain): Create entity inheriting from `AuditableEntity`, implement `IAggregateRoot`
+2. **DbSet** (Application + Infrastructure): Add to `IApplicationDbContext` and `ApplicationDbContext`
+3. **Configuration** (Infrastructure): Create `EntityConfiguration : AuditableEntityConfiguration<Entity>`
+4. **Commands/Queries** (Application): Create in `Features/<FeatureName>/`
+5. **Validators** (Application): Create FluentValidation validators
+6. **Controller** (Web.API): Create in `Controllers/V1/`, use MediatR to send commands/queries
+7. **Migration**: Run `task migration:add -- AddMyEntity`
+
+## Product Feature (CRUD Example)
+
+A complete example demonstrating all patterns is included:
+
+- **Entity**: `Domain/Entities/Product.cs` — rich domain model with business logic
+- **Events**: `Domain/Events/ProductCreatedEvent.cs`, `ProductOutOfStockEvent.cs`, `ProductDeletedEvent.cs`
+- **CQRS**: `Application/Features/Products/` — commands, queries, handlers, validators
+- **EF Config**: `Infrastructure/Data/Configs/ProductConfiguration.cs`
+- **Controller**: `Web.API/Controllers/V1/ProductsController.cs` — full CRUD API
+
+**Patterns demonstrated:**
+- **Soft Delete**: `IsDeleted` + `DeletedAt` fields, filtered by global query filter
+- **Optimistic Concurrency**: `RowVersion` column prevents concurrent update conflicts
+- **Domain Events**: Events dispatched after successful save
+- **Pagination**: `PagedList<T>` wrapper with page/size/total metadata
+- **Query Parameters**: `[FromQuery]` binding with FluentValidation rules visible in OpenAPI
+
+## File Upload Example
+
+Demonstrates file upload with validation:
+
+- **Command**: `Application/Features/Files/Commands/UploadFile/` — command, handler, validator
+- **Controller**: `Web.API/Controllers/V1/FilesController.cs` — upload endpoint
+- **Validation**: Custom FluentValidation extensions for file size, content type, and extension checks
+
+## Removing the Products Example
+
+To start fresh without the example feature:
+
+```shell
+# Linux/Mac
+./scripts/remove-products-example.sh
+```
+
+```powershell
+# Windows (PowerShell)
+.\scripts\remove-products-example.ps1
+```
+
+This removes all Products-related files, updates the DbContext, and self-deletes the scripts. After running:
+1. Run `dotnet build` to verify no errors
+2. Create a new migration or keep the existing Auth migration
+
+## Testing
+
+Three test projects are included:
+
+```
+Tests/
+├── Domain.UnitTests/           # Domain entity tests
+├── Application.UnitTests/      # Handler and validator tests
+└── Web.API.IntegrationTests/   # API integration tests with Testcontainers
+```
+
+```bash
+dotnet test                           # All tests
+dotnet test Tests/Domain.UnitTests    # Specific project
+```
+
+Integration tests use [Testcontainers](https://testcontainers.com/) to spin up a real PostgreSQL database. Docker must be running.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,183 @@
+# Architecture
+
+## Layer Overview
+
+```
+Domain/           Entities, value objects, domain events (no dependencies)
+Application/      CQRS handlers, validators, interfaces (depends on Domain)
+Infrastructure/   EF Core, repositories, external services (depends on Application)
+Web.API/          Controllers, middleware (depends on all layers)
+Common.ApiVersioning/ Shared API versioning library (standalone)
+```
+
+**Dependency Flow:** Domain <- Application <- Infrastructure <- Web.API
+
+## Domain Layer
+
+The innermost layer. Zero external dependencies — not even NuGet packages beyond .NET itself.
+
+**Base classes:**
+- `BaseEntity` — Id + domain events support
+- `AuditableEntity` — Adds CreatedAt/By, ModifiedAt/By (auto-filled by `AuditableEntityInterceptor`)
+- `IAggregateRoot` — Marker for aggregate roots (only these should be directly queried)
+- `ValueObject` — Base for value objects (equality by value, not reference)
+- `IDomainEvent` — Domain event interface
+
+**Why no dependencies?** Domain logic should be testable with nothing but `new` and `Assert`. If your domain needs a database connection or HTTP client, something is wrong.
+
+## Application Layer
+
+Business logic lives here, organized as CQRS handlers.
+
+### CQRS Pattern
+
+Every operation is either a **Command** (changes state) or a **Query** (reads state):
+
+```csharp
+// Command — changes state, returns Result or Result<T>
+public sealed record CreateProductCommand(string Name, decimal Price) : ICommand;
+
+// Query — reads state, always returns Result<T>
+public sealed record GetProductByIdQuery(Guid Id) : IQuery<ProductResponse>;
+```
+
+Each has exactly one handler:
+
+```csharp
+public sealed class CreateProductCommandHandler(IApplicationDbContext context)
+    : ICommandHandler<CreateProductCommand>
+{
+    public async Task<Result> Handle(CreateProductCommand request, CancellationToken ct)
+    {
+        var product = Product.Create(request.Name, request.Price);
+        context.Products.Add(product);
+        await context.SaveChangesAsync(ct);
+        return Result.Success();
+    }
+}
+```
+
+**Why one handler per operation?** Dependencies are explicit. Testing is trivial — construct handler, call `Handle()`, assert result. No mocking 14 unused services to test one method.
+
+### Pipeline Behaviors
+
+MediatR behaviors run automatically before/after every handler:
+
+| Behavior | Purpose |
+|---|---|
+| `ValidationBehavior` | Runs FluentValidation validators before the handler executes. If validation fails, the handler never runs. |
+| `LoggingBehavior` | Logs request execution and timing. |
+| `CachingBehavior` | Caches query results for `ICacheableQuery` implementations. |
+
+**Why pipeline behaviors?** Cross-cutting concerns like validation and logging happen automatically. You can't forget to validate — it's in the pipeline.
+
+### Result Pattern
+
+All handlers return `Result` or `Result<T>` instead of throwing exceptions:
+
+```csharp
+// Failure is explicit in the return type
+public async Task<Result<AuthTokensResponse>> Handle(LoginCommand request, ...)
+{
+    User? user = await context.Users.FirstOrDefaultAsync(u => u.Email == email, ct);
+
+    if (user is null)
+        return Result.Failure<AuthTokensResponse>(Error.From(ErrorCode.InvalidCredentials, "password"));
+
+    // ...
+    return new AuthTokensResponse(accessToken, refreshToken, expiresAt);
+}
+```
+
+See [Error Handling](error-handling.md) for the full error model.
+
+### Interfaces
+
+Application defines interfaces, Infrastructure implements them:
+
+- `IApplicationDbContext` — DbContext abstraction
+- `IRepository<T>` — Generic repository for aggregate roots
+- `IUnitOfWork` — Transaction coordination
+- `ICurrentUserService` — Current authenticated user (throws if not authenticated)
+- `IDateTimeProvider` — Testable time abstraction
+- `IJwtService` — Token generation and validation
+- `IPasswordHasher` — Password hashing
+- `IEmailService` — Email sending
+- `ICacheService` — Cache operations
+- `IBackgroundJobService` — Background job scheduling
+
+**Why interfaces?** Testability and swappability. Mock `IApplicationDbContext` in unit tests. Replace `ICacheService` implementation from Memory to Redis by changing one DI registration.
+
+## Infrastructure Layer
+
+Implements Application interfaces with concrete technology:
+
+- `ApplicationDbContext` — EF Core DbContext implementing `IApplicationDbContext` and `IUnitOfWork`
+- `Repository<T>` — Generic repository implementation
+- `AuditableEntityInterceptor` — Auto-fills CreatedAt/ModifiedAt on save
+- `BaseEntityConfiguration<T>` / `AuditableEntityConfiguration<T>` — EF Core configurations
+- `JwtService`, `PasswordHasher`, `DateTimeProvider` — Service implementations
+
+## Web.API Layer
+
+The outermost layer. Thin controllers that construct commands/queries and return results:
+
+```csharp
+public async Task<IActionResult> Register(RegisterRequest request, CancellationToken ct)
+{
+    var command = new RegisterCommand(request.Email, request.Password, request.DeviceName, Request.Headers.UserAgent);
+    Result<AuthTokensResponse> result = await sender.Send(command, ct);
+    return result.ToActionResult();
+}
+```
+
+Controllers have no business logic. They map HTTP requests to commands and commands to HTTP responses.
+
+**Key infrastructure:**
+- `GlobalExceptionHandlerMiddleware` — Converts unhandled exceptions to RFC 7807 ProblemDetails
+- `ResultExtensions` — Converts `Result<T>` to appropriate HTTP responses with ProblemDetails
+- `CurrentUserService` — Implements `ICurrentUserService` by extracting user ID from JWT claims
+
+## Domain Events
+
+Entities announce business-significant occurrences without knowing who listens:
+
+```csharp
+// 1. Define event (Domain layer)
+public sealed record ProductCreatedEvent(Guid ProductId) : IDomainEvent
+{
+    public DateTime OccurredOn { get; } = DateTime.UtcNow;
+}
+
+// 2. Raise from entity
+public static Product Create(string name, decimal price)
+{
+    var product = new Product { Name = name, Price = price };
+    product.AddDomainEvent(new ProductCreatedEvent(product.Id));
+    return product;
+}
+
+// 3. Handle (Application layer)
+public sealed class ProductCreatedEventHandler
+    : INotificationHandler<DomainEventNotification<ProductCreatedEvent>>
+{
+    public Task Handle(DomainEventNotification<ProductCreatedEvent> notification, CancellationToken ct)
+    {
+        // Send email, update cache, publish to message queue, etc.
+        return Task.CompletedTask;
+    }
+}
+```
+
+Events are collected before `SaveChangesAsync()` and dispatched **after** the transaction commits. This guarantees data consistency — handlers only run if the write succeeded.
+
+## Code Style
+
+Enforced via `.editorconfig` and [CSharpier](https://csharpier.com/):
+
+- File-scoped namespaces required
+- Nullable reference types enabled
+- Private fields: `_camelCase`, private static: `s_camelCase`
+- `var` only when type is apparent
+- Expression-bodied members for single-line methods/properties
+- Line width: 120 characters

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,0 +1,124 @@
+# Authentication & Authorization
+
+## Design Decisions
+
+### Why JWT + Refresh Tokens?
+
+JWTs are stateless — the server doesn't need to hit a database on every request to verify identity. But stateless means you can't revoke them. Refresh tokens solve this: short-lived access tokens (15 minutes) for speed, long-lived refresh tokens (7 days) stored in the database for revocability.
+
+### Why Secure by Default?
+
+Most frameworks require you to add `[Authorize]` to each endpoint. Forget one and you have an unauthenticated route in production. This template inverts the default:
+
+```csharp
+// Program.cs — fallback policy requires authentication on ALL endpoints
+options.FallbackPolicy = new AuthorizationPolicyBuilder()
+    .RequireAuthenticatedUser()
+    .Build();
+```
+
+To make an endpoint public, you explicitly opt out:
+
+```csharp
+[Public]                      // No authentication required (alias for [AllowAnonymous])
+[RequireRole(Role.Admin)]     // Requires Admin role (checked against DB, not JWT)
+[EmailVerified]               // Requires verified email (checked against DB)
+```
+
+### Why Check Roles Against the Database?
+
+JWTs carry claims set at token creation time. If you put roles in the JWT, revoking a user's admin access doesn't take effect until their token expires. This template puts only the user ID in the JWT and checks roles against the database on each request via custom authorization handlers. Role changes take effect immediately.
+
+## Auth Endpoints
+
+| Endpoint              | Method | Auth     | Description              |
+|-----------------------|--------|----------|--------------------------|
+| `/Auth/Register`      | POST   | Public   | Register new user        |
+| `/Auth/Login`         | POST   | Public   | Login, returns tokens    |
+| `/Auth/Refresh`       | POST   | Public   | Refresh access token     |
+| `/Auth/Logout`        | POST   | Required | Revoke refresh token(s)  |
+| `/Auth/Me`            | GET    | Required | Get current user profile |
+| `/Auth/Sessions`      | GET    | Required | List active sessions     |
+| `/Auth/Sessions/{id}` | DELETE | Required | Revoke specific session  |
+| `/Auth/ForgotPassword`| POST   | Public   | Initiate password reset  |
+| `/Auth/ResetPassword` | POST   | Public   | Reset password with token|
+| `/Auth/SendVerificationEmail` | POST | Required | Send verification email |
+| `/Auth/VerifyEmail`   | POST   | Required | Verify email with token  |
+
+## Multi-Device Support
+
+- Each login creates a separate refresh token (session)
+- Users can be logged in on multiple devices simultaneously
+- Sessions can be viewed and revoked individually
+- Device name and user agent stored for identification
+
+## JWT Configuration
+
+Configure via environment variables or `appsettings.json`:
+
+```bash
+JWT__SECRETKEY=your-secret-key-min-32-chars
+JWT__ISSUER=MyApp
+JWT__AUDIENCE=MyApp
+JWT__ACCESSTOKENEXPIRATIONMINUTES=15
+JWT__REFRESHTOKENEXPIRATIONDAYS=7
+```
+
+The access token contains only:
+- `sub` — User ID
+- `jti` — Unique token ID
+
+No roles, no email, no other claims. Authorization is checked against the database.
+
+## ICurrentUserService
+
+Handlers that need the current user inject `ICurrentUserService`:
+
+```csharp
+public sealed class LogoutCommandHandler(IApplicationDbContext context, ICurrentUserService currentUserService)
+    : ICommandHandler<LogoutCommand>
+{
+    public async Task<Result> Handle(LogoutCommand request, CancellationToken ct)
+    {
+        Guid userId = currentUserService.UserId; // Throws if not authenticated
+        // ...
+    }
+}
+```
+
+`UserId` is `Guid`, not `Guid?`. If called from a non-authenticated endpoint, it throws `InvalidOperationException`, which the exception middleware converts to a 500. This is intentional: it surfaces developer mistakes loudly rather than masquerading as a user-facing 401.
+
+You don't need to guard against null — the fallback policy guarantees authentication before the handler runs.
+
+## Creating Custom Guards
+
+Use `[EmailVerified]` as a template:
+
+1. **Attribute** in `Web.API/Authorization/`:
+   ```csharp
+   [AttributeUsage(AttributeTargets.Class | AttributeTargets.Method)]
+   public sealed class EmailVerifiedAttribute : AuthorizeAttribute
+   {
+       public EmailVerifiedAttribute() => Policy = "EmailVerified";
+   }
+   ```
+
+2. **Requirement** in `Web.API/Authorization/Requirements/`:
+   ```csharp
+   public sealed class EmailVerifiedRequirement : IAuthorizationRequirement;
+   ```
+
+3. **Handler** in `Web.API/Authorization/Handlers/`:
+   ```csharp
+   public sealed class EmailVerifiedAuthorizationHandler
+       : AuthorizationHandler<EmailVerifiedRequirement>
+   {
+       protected override async Task HandleRequirementAsync(
+           AuthorizationHandlerContext context, EmailVerifiedRequirement requirement)
+       {
+           // Extract user ID, query database, call context.Succeed() or context.Fail()
+       }
+   }
+   ```
+
+4. **Register** the policy name in `AuthorizationPolicyProvider.cs`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,176 @@
+# Configuration
+
+All settings can be configured via environment variables or `appsettings.json`. Environment variables override `appsettings.json`. See `.env.example` for all available variables.
+
+## CORS
+
+```json
+"Cors": {
+  "AllowedOrigins": ["https://yourdomain.com", "https://*.yourdomain.com"]
+}
+```
+
+Or via environment variable:
+```bash
+CORS__ALLOWEDORIGINS=https://yourdomain.com,https://*.yourdomain.com
+```
+
+**Wildcard support:** `https://*.example.com` matches any subdomain.
+
+**Behavior:**
+- With origins configured: Strict CORS with credentials support
+- In Development without origins: Allow any origin (no credentials)
+
+## Caching
+
+Optional response caching with Memory or Redis backends.
+
+```json
+"Caching": {
+  "Enabled": false,
+  "Provider": "Memory",
+  "Redis": {
+    "ConnectionString": "localhost:6379"
+  },
+  "DefaultExpirationMinutes": 5
+}
+```
+
+**Providers:**
+- `Memory` — In-process memory cache (default, single instance only)
+- `Redis` — Distributed cache (multiple instances)
+- `None` / disabled — No-op (zero overhead)
+
+**Usage in queries:**
+```csharp
+public sealed record GetProductByIdQuery(Guid Id)
+    : IQuery<ProductResponse>, ICacheableQuery
+{
+    public string CacheKey => $"products:{Id}";
+}
+```
+
+Implement `ICacheableQuery` and `CachingBehavior` handles the rest.
+
+## Rate Limiting
+
+```json
+"RateLimiting": {
+  "Global": { "PermitLimit": 100, "WindowMinutes": 1 },
+  "Policies": {
+    "Auth":    { "Limit": 5,  "Window": 60 },
+    "Api":     { "Limit": 30, "Window": 60 },
+    "Strict":  { "Limit": 10, "Window": 60 },
+    "Relaxed": { "Limit": 60, "Window": 60 }
+  }
+}
+```
+
+- **Global limiter** — Applies to all requests per IP
+- **Named policies** — Apply to endpoints with `[RateLimit("Api")]` or `[RateLimit("Auth", Per.User)]`
+- **Partitioning** — Per IP (default), per User, or per Session
+
+When rate limited, returns `429 Too Many Requests`.
+
+## Background Jobs
+
+```json
+"BackgroundJobs": {
+  "Provider": "Instant"
+}
+```
+
+**Providers:**
+- `Instant` — Fire-and-forget after response (default, good for development)
+- `Memory` — In-memory queue with background worker
+- `None` — Disabled, jobs are dropped
+
+**Usage:**
+```csharp
+public class MyHandler(IBackgroundJobService jobs)
+{
+    public async Task Handle(...)
+    {
+        await jobs.EnqueueAsync(new SendWelcomeEmailCommand(userId));
+        await jobs.ScheduleAsync(new CleanupCommand(), TimeSpan.FromHours(1));
+    }
+}
+```
+
+**For production**, replace with [Hangfire](https://www.hangfire.io/) (persistence, retries, dashboard) or message queues (RabbitMQ, Azure Service Bus) for distributed scenarios.
+
+## Health Checks
+
+| Endpoint        | Description                                     |
+|-----------------|-------------------------------------------------|
+| `/health/live`  | Liveness probe — is the app running?            |
+| `/health/ready` | Readiness probe — is the app ready for traffic? |
+
+The readiness check includes database connectivity.
+
+```bash
+curl http://localhost:5141/health/ready
+```
+
+## Observability
+
+### Serilog Structured Logging
+
+```json
+"Serilog": {
+  "MinimumLevel": {
+    "Default": "Information",
+    "Override": {
+      "Microsoft": "Warning",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}
+```
+
+### Correlation ID
+
+Every request gets a unique correlation ID for distributed tracing:
+
+- **Header**: `X-Correlation-ID`
+- Reads from request header or generates new GUID
+- Included in all logs via Serilog LogContext
+- Returned in response headers
+- Included in error responses (ProblemDetails)
+
+```bash
+curl -H "X-Correlation-ID: my-trace-123" http://localhost:5141/Products
+```
+
+### Request Logging
+
+Debug-level logging of HTTP requests/responses:
+- Logs method, path, status code, and timing
+- Excludes health check endpoints
+- Redacts sensitive headers (Authorization, Cookie, API keys)
+
+Enable by setting Serilog minimum level to `Debug`.
+
+### OpenTelemetry
+
+For production observability, add OpenTelemetry instrumentation:
+
+```xml
+<PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+<PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+<PackageReference Include="OpenTelemetry.Instrumentation.EntityFrameworkCore" Version="1.10.0-beta.1" />
+<PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.11.2" />
+```
+
+See [OpenTelemetry .NET documentation](https://opentelemetry.io/docs/languages/net/) for setup.
+
+## API Versioning
+
+Header-based versioning (`x-api-version`) with namespace conventions (`Controllers.V1` -> version 1).
+
+| Endpoint                  | Description                         |
+|---------------------------|-------------------------------------|
+| `/openapi/{version}.json` | OpenAPI 3.0 specification           |
+| `/scalar`                 | Scalar interactive documentation UI |
+
+For complete documentation, see [Common.ApiVersioning/README.md](../Common.ApiVersioning/README.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,62 @@
+# Deployment
+
+## Docker Compose (Production)
+
+```bash
+# Configure production values in .env
+task prod:up     # Build and start production stack
+task prod:logs   # View logs
+task prod:down   # Stop
+```
+
+**Production services:**
+- **PostgreSQL 18** — Database (internal network only)
+- **Redis 8** — Distributed caching (internal network only, optional)
+- **API** — ASP.NET Core application
+- **Nginx** — Reverse proxy with HTTPS termination
+
+## VM/EC2 Deployment
+
+Build a self-contained package for deployment to VMs:
+
+```bash
+# Build for Linux x64 (default)
+task deploy:build
+
+# Build for different runtime
+task deploy:build DEPLOY_RUNTIME=linux-arm64  # ARM64 (AWS Graviton)
+task deploy:build DEPLOY_RUNTIME=win-x64      # Windows
+
+# Create deployment package
+task deploy:package          # Creates .tar.gz (Linux/Mac)
+task deploy:package:windows  # Creates .zip (Windows)
+```
+
+### Systemd Service
+
+Example unit file (`/etc/systemd/system/myapp.service`):
+
+```ini
+[Unit]
+Description=ASP.NET Clean Architecture API
+After=network.target
+
+[Service]
+Type=notify
+User=www-data
+WorkingDirectory=/opt/myapp
+ExecStart=/opt/myapp/Web.API
+Restart=always
+RestartSec=10
+Environment=ASPNETCORE_ENVIRONMENT=Production
+Environment=ASPNETCORE_URLS=http://localhost:5000
+
+[Install]
+WantedBy=multi-user.target
+```
+
+```bash
+sudo systemctl enable myapp
+sudo systemctl start myapp
+sudo systemctl status myapp
+```

--- a/docs/error-handling.md
+++ b/docs/error-handling.md
@@ -1,0 +1,181 @@
+# Error Handling
+
+## Design Decisions
+
+### Why Typed Error Codes?
+
+When a frontend receives `{ "detail": "Email is already registered." }`, it has to match on an English string to show the right error message. Rename the string, and the frontend breaks. Translate the API to another language, and the frontend breaks.
+
+This template uses a typed `ErrorCode` enum. Every error response includes an `errorCode` field:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.10",
+  "title": "Conflict",
+  "status": 409,
+  "detail": "Email is already registered.",
+  "errorCode": "EmailTaken"
+}
+```
+
+The frontend matches on `errorCode`, not `detail`. The `detail` field is for developers reading logs. The `errorCode` is for programmatic handling and i18n.
+
+### Why the Result Pattern?
+
+Exceptions are invisible control flow. A method that returns `User` might throw three different exceptions — you won't know until you read the implementation. The Result pattern makes failure explicit:
+
+```csharp
+// The return type tells you this can fail
+Result<AuthTokensResponse> result = await sender.Send(loginCommand, ct);
+```
+
+See [Architecture](architecture.md) for more on the Result pattern.
+
+## Creating Errors in Handlers
+
+### Error.From() — The Primary Pattern
+
+`Error.From(ErrorCode)` is the standard way to create errors in handlers:
+
+```csharp
+// Simple error — code determines status code and default message
+return Result.Failure(Error.From(ErrorCode.EmailAlreadyVerified));
+
+// With a field — produces a field-level error in the response
+return Result.Failure(Error.From(ErrorCode.InvalidCredentials, "password"));
+
+// With a message override — for dynamic messages
+return Result.Failure(Error.From(ErrorCode.UsernameCooldown, message: $"Try again after {date}"));
+```
+
+### Error.NotFound() — Entity Lookups
+
+For internal entity lookups where a coded error isn't useful to the frontend:
+
+```csharp
+return Result.Failure(Error.NotFound("Product", request.Id));
+// Produces: { "status": 404, "detail": "Product with id '...' was not found." }
+```
+
+### Convenience Factories
+
+Uncoded errors for generic situations:
+
+```csharp
+Error.Unauthorized()  // 401, default message
+Error.Forbidden()     // 403, default message
+```
+
+## ErrorCode Enum
+
+Every `ErrorCode` value is decorated with `[ErrorInfo(statusCode, defaultMessage)]`:
+
+```csharp
+public enum ErrorCode
+{
+    [ErrorInfo(400, "Invalid email or password.")]
+    InvalidCredentials,
+
+    [ErrorInfo(409, "Email is already registered.")]
+    EmailTaken,
+
+    [ErrorInfo(401, "Authentication is required.")]
+    NotAuthenticated,
+
+    // ...
+}
+```
+
+The status code and default message are derived from the attribute automatically. To add a new error code, add a value to the enum with an `[ErrorInfo]` attribute — no other changes needed.
+
+The enum is also exposed in the OpenAPI schema, so API consumers can see all possible error codes.
+
+## Validation Errors
+
+There are two kinds of errors that produce field-level details:
+
+### FluentValidation Errors (Automatic)
+
+FluentValidation runs automatically in the MediatR pipeline via `ValidationBehavior`. If validation fails, the handler never executes:
+
+```json
+{
+  "status": 400,
+  "detail": "One or more validation errors occurred.",
+  "errorCode": "ValidationFailed",
+  "errors": {
+    "Email": [{ "detail": "Email is required." }],
+    "Password": [
+      { "detail": "Password must be at least 8 characters." },
+      { "detail": "Password must contain at least one uppercase letter." }
+    ]
+  }
+}
+```
+
+When `errorCode` is `ValidationFailed`, the `errors` dictionary is always present with at least one entry.
+
+### Handler Field Errors (Error.From with field)
+
+When a handler uses `Error.From(ErrorCode.X, "field")`, the response includes a single-field error with the specific code:
+
+```json
+{
+  "status": 400,
+  "detail": "Invalid email or password.",
+  "errorCode": "InvalidCredentials",
+  "errors": {
+    "password": [{ "code": "InvalidCredentials", "detail": "Invalid email or password." }]
+  }
+}
+```
+
+The difference: FluentValidation errors have no per-field `code` (they all share `ValidationFailed`). Handler field errors have a specific `code` per field.
+
+## ProblemDetails Response Format
+
+All error responses follow RFC 7807:
+
+```json
+{
+  "type": "https://tools.ietf.org/html/rfc9110#section-15.5.1",
+  "title": "Bad Request",
+  "status": 400,
+  "detail": "Human-readable description of what went wrong.",
+  "errorCode": "InvalidCredentials",
+  "errors": {
+    "fieldName": [
+      { "code": "ErrorCodeName", "detail": "Field-level message." }
+    ]
+  }
+}
+```
+
+| Field | Always present | Description |
+|---|---|---|
+| `type` | Yes | RFC 9110 reference URI for the status code |
+| `title` | Yes | HTTP status text (e.g., "Bad Request") |
+| `status` | Yes | HTTP status code |
+| `detail` | Yes | Human-readable error description |
+| `errorCode` | Yes | `ErrorCode` enum value (for programmatic matching) |
+| `errors` | Only for validation/field errors | Dictionary of field name to error details |
+
+## Frontend Consumption
+
+```typescript
+// Match on errorCode, not detail
+switch (response.errorCode) {
+  case "InvalidCredentials":
+    showError(t("auth.invalidCredentials"));
+    break;
+  case "EmailTaken":
+    showFieldError("email", t("auth.emailTaken"));
+    break;
+  case "ValidationFailed":
+    // Show field-level errors from errors dictionary
+    for (const [field, errors] of Object.entries(response.errors)) {
+      showFieldError(field, errors.map(e => e.detail).join(", "));
+    }
+    break;
+}
+```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,165 @@
+# Getting Started
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- [Docker Desktop](https://www.docker.com/products/docker-desktop)
+- [Task](https://taskfile.dev/) (task runner)
+- [mkcert](https://github.com/FiloSottile/mkcert) *(optional, for local HTTPS)*
+
+## Using as Template
+
+### Installation
+
+```bash
+git clone https://github.com/AnriaruDoragon/ASP-Clean-Architecture
+dotnet new install ./ASPCleanArchitecture
+```
+
+### Create a New Project
+
+```bash
+# Default: all features included (with auto-setup)
+dotnet new aspclean -n MyApp --allow-scripts yes
+
+# Without auto-setup (manual post-creation steps)
+dotnet new aspclean -n MyApp
+
+# Without Docker files
+dotnet new aspclean -n MyApp --IncludeDocker false --allow-scripts yes
+
+# Without example Product feature
+dotnet new aspclean -n MyApp --IncludeExamples false --allow-scripts yes
+
+# Minimal: no examples, no docker, no tests
+dotnet new aspclean -n MyApp --IncludeExamples false --IncludeDocker false --IncludeTests false --allow-scripts yes
+```
+
+> **Note:** `--allow-scripts yes` automatically runs post-creation scripts (restore, copy .env, create migration).
+> Without it, you'll be prompted to confirm each action or can run them manually.
+
+### Template Parameters
+
+| Parameter           | Default | Description                   |
+|---------------------|---------|-------------------------------|
+| `--IncludeExamples` | `true`  | Include Products CRUD example |
+| `--IncludeDocker`   | `true`  | Include Docker/compose files  |
+| `--IncludeTests`    | `true`  | Include test projects         |
+
+### After Creating a Project
+
+We recommend installing [Taskfile](https://taskfile.dev/docs/installation) to use predefined tasks.
+
+With `--allow-scripts yes`, steps 1-3 run automatically.
+
+```bash
+cd MyApp
+
+# 1. Setup environment (auto)
+cp .env.example .env
+
+# 2. Restore packages (auto)
+task restore
+
+# 3. Create initial migration (auto)
+task migration:add -- Init
+
+# 4. (Optional) Setup local HTTPS
+task certs:setup:windows  # Windows (run as Administrator)
+task certs:setup          # Linux/Mac (uses sudo)
+
+# 5. Start development
+task docker:up
+```
+
+## Development Setup
+
+### First-Time Setup
+
+1. **Copy environment file and restore tools:**
+   ```bash
+   cp .env.example .env
+   dotnet tool restore
+   ```
+
+2. **(Optional) Local HTTPS domain setup:**
+   ```bash
+   # Generate certificates and configure hosts (requires mkcert)
+   # Run as admin/sudo to auto-add hosts entry
+   task certs:setup:windows  # Windows (run as Administrator)
+   task certs:setup          # Linux/Mac (uses sudo)
+   ```
+
+### Development Workflow
+
+**Windows/Mac** (recommended): Run DB + Redis in Docker, .NET locally via IDE:
+```bash
+task docker:up   # Start infrastructure (DB, Redis, Traefik)
+task watch       # Run API with hot-reload
+```
+
+**Linux**: Run everything in Docker:
+```bash
+task docker:up   # Starts full stack including API container
+```
+
+### Development Endpoints
+
+| Endpoint          | URL                                                 |
+|-------------------|-----------------------------------------------------|
+| API (direct)      | http://localhost:5141                               |
+| API (via Traefik) | https://api.app.localhost *(requires hosts entry)*  |
+| Scalar API docs   | http://localhost:5141/scalar/v1                     |
+| Traefik Dashboard | http://localhost:8080                               |
+
+### Redis Caching (Optional)
+
+Redis is available but not started by default. To enable:
+
+```bash
+# Set in .env
+CACHING__PROVIDER=Redis
+
+# Start with cache profile
+docker compose --profile cache up -d
+```
+
+## Docker Commands
+
+| Command                | Description                                   |
+|------------------------|-----------------------------------------------|
+| `task docker:up`       | Smart start (Windows/Mac: infra, Linux: full) |
+| `task docker:up:infra` | Start infrastructure only                     |
+| `task docker:up:full`  | Start full stack with API container           |
+| `task docker:down`     | Stop all containers                           |
+| `task docker:logs`     | View container logs                           |
+| `task docker:clean`    | Remove containers and volumes                 |
+
+## Build & Test Commands
+
+```bash
+# Build
+task build              # Debug build
+task build:release      # Release build
+
+# Run
+task run                # Run API
+task watch              # Run with hot-reload
+
+# Test
+task test               # All tests
+task test:unit          # Unit tests only
+task test:integration   # Integration tests
+
+# EF Core Migrations
+task migration:add -- Name    # Create migration
+task db:update                # Apply migrations
+task db:shell                 # PostgreSQL shell
+
+# Utilities
+task format             # Format code (dotnet format + CSharpier)
+task format:check       # Check formatting without changes
+task info               # Show environment info
+```
+
+View all commands: `task --list-all`


### PR DESCRIPTION
- Expected failure errors are enumerated in `ErrorCode` enum
- Replaced `Error.Create()`  with `Error.From(ErrorCode)` which now resolves error specific code, also supports specific field like previous `ValidationError.ForField(field, ErrorCode)` -> `Error.From(ErrorCode, field)`. 
- `ValidationError` now only responsible for handling FluentValidation, using predefined `ErrorCode.ValidationFailed` which should not be thrown from command/query handlers or services, when throwing this code, Interceptor ensures that response contains `Errors` array, which will be empty unless field is specified. By default FluentValidation error response won't include code inside `FieldError`, because all codes in this case will be the same.
- Changed type for `ErrorCode` inside ProblemDetailsResponse from string to `ErrorCode`, so OpenAPI properly displays all available options.
- Updated documentation
- Minor fixes an improvements